### PR TITLE
Address issues with docker compose up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Build outputs
-dist
 build
 *.tsbuildinfo
 
@@ -29,7 +28,6 @@ Thumbs.db
 .gitignore
 
 # Documentation
-docs
 *.md
 !README.md
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # AASWE MCP Server - Main application
   aaswe-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,3 @@ volumes:
 networks:
   aaswe-network:
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16


### PR DESCRIPTION
Hello @AssahBismarkabah - I faced issues running `docker compose up` on the repo and would like to bring these issues (and a potential fix) to your attention.

First, the `dist` and `docs` directories are copied during the `docker build` phase but these are unexpectedly added to `.dockerignore`, making them invisible. Additionally, I deduce that the `npm run build` command is expected to be run before `docker compose up`, so the `dist` directory is generated. But is that intentional?

Lastly, could we have the docker network address dynamically assigned? I personally had a conflict with another network locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Docker build context now includes distribution and documentation directories so those assets are available inside container builds.
  - Container networking simplified to rely on Docker’s default IPAM settings, reducing subnet conflicts and improving cross-environment compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->