### PR TITLE
Introduce `RAGSparqlService` for integrating RAG with SPARQL-based RD…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aaswe/codebase-ai",
-  "version": "1.1.5",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aaswe/codebase-ai",
-      "version": "1.1.5",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@aaswe/codebase-ai": "^1.1.0",
@@ -636,6 +636,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@browserbasehq/sdk": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.6.0.tgz",
+      "integrity": "sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@browserbasehq/sdk/node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@browserbasehq/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@browserbasehq/stagehand": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@browserbasehq/stagehand/-/stagehand-1.14.0.tgz",
+      "integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.27.3",
+        "@browserbasehq/sdk": "^2.0.0",
+        "ws": "^8.18.0",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.42.1",
+        "deepmerge": "^4.3.1",
+        "dotenv": "^16.4.5",
+        "openai": "^4.62.1",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/@anthropic-ai/sdk": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
+      "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
@@ -1002,16 +1088,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1192,6 +1268,39 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ibm-cloud/watsonx-ai": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.6.12.tgz",
+      "integrity": "sha512-ZMvkQgucWj2NDRl/7+RVislV3JYyS7iXUbPwJyQt4M0gcaVChM6PayZqdxAbqL4hdbXmh/k/uvhUynZrmpa0LQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^18.0.0",
+        "extend": "3.0.2",
+        "form-data": "^4.0.4",
+        "ibm-cloud-sdk-core": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@ibm-cloud/watsonx-ai/node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@ibm-cloud/watsonx-ai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
@@ -2629,6 +2738,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2697,7 +2822,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.8.2.tgz",
       "integrity": "sha512-855DR0ChetZLarblio5eM0yLwxA9Dqq50t8StXKp5bAtLT0G+rZ+eRzzqxl37sPqQKjUudSYypz55o6nNhbz0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -2710,7 +2835,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.2.tgz",
       "integrity": "sha512-WtMScno3+eBpTac1Uav2zugXEoXqaU23YznwvFgkPwBQVwEHTDgOG7uEAObtZ/Nyn8SmAMbqkEubJaMOvnqdsQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2"
@@ -2723,7 +2848,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.8.2.tgz",
       "integrity": "sha512-uxpVfas3I0LccBX9rIfDgJ0dBrUa3+0Gc8sEwmQQH0vHi7C1Rx1Qn8Nv1QWz5bohoeIXMICFZRcyDONvum2l/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -2736,7 +2861,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.8.2.tgz",
       "integrity": "sha512-cNv7HlgayavCBXqPXgaS97DRPVWFznuzsAmmuemi2TMCx5scwLiP50TeZvUS06h/MG96YNPe6A0Zt57yayfxwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -2749,7 +2874,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.8.2.tgz",
       "integrity": "sha512-g2NlHM07fK8H4k+613NBsk3y70R2JIM2dPMSkhIjl2Z17SYvaYKdusz85d7VYOrZBWtDrHV/WD2E3vGu+zni8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -2784,6 +2909,13 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
@@ -2884,6 +3016,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2946,6 +3088,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/node": {
       "version": "22.18.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
@@ -2977,6 +3126,13 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -3045,6 +3201,16 @@
         "@typescript-eslint/parser": "^8.41.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -3450,6 +3616,18 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -3716,6 +3894,13 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4018,7 +4203,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
@@ -4281,7 +4466,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4342,6 +4526,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/detect-newline": {
@@ -4405,6 +4598,16 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.209",
@@ -4660,16 +4863,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4899,6 +5092,13 @@
       "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5051,6 +5251,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5116,6 +5334,27 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -5165,6 +5404,15 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -5419,7 +5667,7 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -5511,6 +5759,50 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/ibm-cloud-sdk-core": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.2.tgz",
+      "integrity": "sha512-5VFkKYU/vSIWFJTVt392XEdPmiEwUJqhxjn1MRO3lfELyU2FB+yYi8brbmXUgq+D1acHR1fpS7tIJ6IlnrR9Cg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.19.80",
+        "@types/tough-cookie": "^4.0.0",
+        "axios": "^1.11.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "extend": "3.0.2",
+        "file-type": "16.5.4",
+        "form-data": "^4.0.4",
+        "isstream": "0.1.2",
+        "jsonwebtoken": "^9.0.2",
+        "mime-types": "2.1.35",
+        "retry-axios": "^2.6.0",
+        "tough-cookie": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5532,9 +5824,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -5739,6 +6032,13 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -7108,6 +7408,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7383,6 +7729,48 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7396,6 +7784,13 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -7644,7 +8039,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/neo4j-driver": {
@@ -8082,6 +8477,20 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8179,6 +8588,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8250,11 +8706,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8276,6 +8751,13 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -8347,6 +8829,23 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -8376,7 +8875,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.8.2.tgz",
       "integrity": "sha512-31vunZj07++Y1vcFGcnNWEf5jPoTkGARgfWI4+Tk55vdwHxhAvug8VEtW7Cx+/h47NuJTEg/JL77zAwC6E0OeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@redis/bloom": "5.8.2",
@@ -8415,6 +8914,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -8486,6 +8992,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/retry-axios": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
+      "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10.7.0"
+      },
+      "peerDependencies": {
+        "axios": "*"
       }
     },
     "node_modules/reusify": {
@@ -8681,7 +9200,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8924,6 +9443,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9045,6 +9582,40 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -9327,6 +9898,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -9366,6 +9947,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -9464,12 +10056,19 @@
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.2.0.tgz",
+      "integrity": "sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "workspaces": [
+        "test/benchmark-test",
+        "test/rollup-test",
+        "test/webpack-test"
+      ],
       "engines": {
-        "node": ">= 14"
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -9581,7 +10180,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,6 +56,7 @@ program
   .option('--project-path <path>', 'Custom project path', process.cwd())
   .option('--no-watch', 'Disable TTL file watching')
   .option('--debug', 'Enable debug logging')
+  .option('--enable-rag-sparql', 'Enable RAG + SPARQL integration (Layer 3)')
   .action(async (options) => {
     try {
       if (options.debug) {
@@ -77,6 +78,19 @@ program
       const config = options.config ?
         require(join(projectPath, options.config)) :
         createDefaultMCPConfig();
+
+      // Enable RAG+SPARQL integration if requested
+      if (options.enableRagSparql) {
+        try {
+          if (!config.integration) config.integration = {} as any;
+          if (!config.integration.layer3Config) config.integration.layer3Config = {} as any;
+          if (!config.integration.layer3Config.ragSparql) config.integration.layer3Config.ragSparql = { enabled: true };
+          else config.integration.layer3Config.ragSparql.enabled = true;
+          logger.info('RAG+SPARQL integration enabled via CLI flag');
+        } catch (e) {
+          logger.warn('Failed to set RAG+SPARQL flag in config', { error: e });
+        }
+      }
 
       config.server.port = parseInt(options.port);
       config.ttl.watchEnabled = options.watch;

--- a/src/services/layer3/langchain-rag/types.ts
+++ b/src/services/layer3/langchain-rag/types.ts
@@ -20,7 +20,6 @@ export interface RAGConfig {
   llm: {
     provider: 'openai' | 'anthropic' | 'local';
     model: string;
-    temperature: number;
     maxTokens: number;
   };
   

--- a/src/services/layer3/rag-sparql-integration/RAGSparqlService.ts
+++ b/src/services/layer3/rag-sparql-integration/RAGSparqlService.ts
@@ -1,0 +1,122 @@
+import { Document } from '@langchain/core/documents';
+import logger from '../../../utils/logger';
+import { RAGEngine } from '../langchain-rag/RAGEngine';
+import type { QueryContext, RAGConfig } from '../langchain-rag/types';
+import { SPARQLQueryEngine } from '../sparql-query-engine/SPARQLQueryEngine';
+import type { SPARQLEngineConfig, SPARQLQueryResponse } from '../sparql-query-engine/types';
+import { InMemoryRDFStore } from '../../layer2/in-memory-rdf';
+import { PassthroughNL2SPARQLTranslator, RAGSparqlRequest, RAGSparqlAnswer, RAGSparqlOptions, rowsToDocuments } from './types';
+
+/**
+ * RAGSparqlService orchestrates: NL question -> SPARQL over RDF -> RAG answer
+ */
+export class RAGSparqlService {
+  private rag: RAGEngine;
+  private sparql: SPARQLQueryEngine;
+
+  constructor(options: RAGSparqlOptions = {}) {
+    // Initialize SPARQL engine
+    if (options.sparqlEngine) {
+      this.sparql = options.sparqlEngine;
+    } else {
+      const rdfStore = new InMemoryRDFStore({
+        persistence: { enabled: false }
+      } as any);
+      const sparqlConfig: SPARQLEngineConfig = {
+        rdf: { timeout: 30000, maxResults: 1000 },
+        llm: { provider: 'openai', model: 'gpt-4', temperature: 0.1, maxTokens: 1000 },
+        queryGeneration: { maxRetries: 2, timeoutMs: 15000, validateSyntax: true, optimizeQuery: true, usePatterns: true },
+        prefixes: {
+          'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+          'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+          'owl': 'http://www.w3.org/2002/07/owl#',
+          'xsd': 'http://www.w3.org/2001/XMLSchema#',
+          'aaswe': 'http://aaswe.org/ontology#'
+        },
+        response: { includeQuery: true, includeExplanation: true, formatResults: true, maxResults: 100 },
+        caching: { enabled: true, ttl: 300000, maxSize: 1000 }
+      };
+      this.sparql = new SPARQLQueryEngine(sparqlConfig, rdfStore);
+    }
+
+    // Initialize RAG engine
+    if (options.ragEngine) {
+      this.rag = options.ragEngine;
+    } else {
+      const ragConfig: RAGConfig = {
+        vectorStore: { type: 'memory', dimensions: 1536, similarity: 'cosine' },
+        retrieval: { topK: 5, scoreThreshold: 0.7, maxTokens: 4000, contextWindow: 8000 },
+        llm: { provider: 'openai', model: 'gpt-4', temperature: 0.1, maxTokens: 1000 },
+        embeddings: { provider: 'openai', model: 'text-embedding-ada-002', dimensions: 1536 },
+        cache: { enabled: true, ttl: 300000, maxSize: 1000 }
+      };
+      this.rag = new RAGEngine(ragConfig);
+    }
+  }
+
+  /**
+   * Ask a natural language question and get an enriched answer using RDF + RAG
+   */
+  async ask(req: RAGSparqlRequest): Promise<RAGSparqlAnswer> {
+    const start = Date.now();
+    const translator = new PassthroughNL2SPARQLTranslator();
+
+    try {
+      // Step 1: Translate question (hint) and execute SPARQL via engine
+      const hint = await translator.translate(req.question);
+      logger.debug('RAGSparqlService: NL2SPARQL hint generated', { hint });
+
+      if ((this.sparql as any).initialize) {
+        await (this.sparql as any).initialize();
+      }
+
+      const sparqlResp: SPARQLQueryResponse = await this.sparql.query(hint);
+
+      // Step 2: Convert RDF results to Documents
+      const docs: Document[] = rowsToDocuments(sparqlResp, req.maxContextDocs || 20);
+      if (docs.length > 0) {
+        await this.rag.addDocuments(docs);
+      }
+
+      // Step 3: RAG answer using RDF-backed context
+      const qc: QueryContext = { query: req.question, intent: 'documentation', scope: 'project' } as any;
+      const ragResp = await this.rag.query(qc);
+
+      const processingTime = Date.now() - start;
+      const answer: RAGSparqlAnswer = {
+        question: req.question,
+        answer: ragResp.answer,
+        confidence: ragResp.reasoning?.confidence || (ragResp.sources?.length ? 0.8 : 0.4),
+        contextDocs: docs.length,
+        sparql: {
+          query: sparqlResp.generatedSPARQL?.sparql || 'N/A',
+          explanation: sparqlResp.explanation
+        },
+        rdfSummary: sparqlResp.formattedResponse,
+        metadata: {
+          processingTime,
+          rdfResultCount: sparqlResp.executionResult?.summary?.resultCount || 0,
+          cacheHit: Boolean(sparqlResp.metadata?.cacheHit)
+        }
+      };
+
+      logger.info('RAGSparqlService: Answer generated', {
+        question: req.question,
+        contextDocs: docs.length,
+        rdfResultCount: sparqlResp.executionResult?.summary?.resultCount || 0,
+        processingTime
+      });
+
+      return answer;
+    } catch (error) {
+      logger.error('RAGSparqlService: Failed to generate answer', { error });
+      return {
+        question: req.question,
+        answer: `Error: ${error instanceof Error ? error.message : String(error)}`,
+        confidence: 0,
+        contextDocs: 0,
+        metadata: { error: true }
+      };
+    }
+  }
+}

--- a/src/services/layer3/rag-sparql-integration/RAGSparqlService.ts
+++ b/src/services/layer3/rag-sparql-integration/RAGSparqlService.ts
@@ -24,7 +24,7 @@ export class RAGSparqlService {
       } as any);
       const sparqlConfig: SPARQLEngineConfig = {
         rdf: { timeout: 30000, maxResults: 1000 },
-        llm: { provider: 'openai', model: 'gpt-4', temperature: 0.1, maxTokens: 1000 },
+        llm: { provider: 'openai', model: 'gpt-4', maxTokens: 1000 },
         queryGeneration: { maxRetries: 2, timeoutMs: 15000, validateSyntax: true, optimizeQuery: true, usePatterns: true },
         prefixes: {
           'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
@@ -46,7 +46,7 @@ export class RAGSparqlService {
       const ragConfig: RAGConfig = {
         vectorStore: { type: 'memory', dimensions: 1536, similarity: 'cosine' },
         retrieval: { topK: 5, scoreThreshold: 0.7, maxTokens: 4000, contextWindow: 8000 },
-        llm: { provider: 'openai', model: 'gpt-4', temperature: 0.1, maxTokens: 1000 },
+        llm: { provider: 'openai', model: 'gpt-4', maxTokens: 1000 },
         embeddings: { provider: 'openai', model: 'text-embedding-ada-002', dimensions: 1536 },
         cache: { enabled: true, ttl: 300000, maxSize: 1000 }
       };

--- a/src/services/layer3/rag-sparql-integration/index.ts
+++ b/src/services/layer3/rag-sparql-integration/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './RAGSparqlService';

--- a/src/services/layer3/rag-sparql-integration/types.ts
+++ b/src/services/layer3/rag-sparql-integration/types.ts
@@ -1,0 +1,75 @@
+import { Document } from '@langchain/core/documents';
+import { RAGEngine } from '../langchain-rag/RAGEngine';
+import { SPARQLQueryEngine } from '../sparql-query-engine/SPARQLQueryEngine';
+import type { SPARQLQueryResponse } from '../sparql-query-engine/types';
+import logger from '../../../utils/logger';
+
+export interface RAGSparqlOptions {
+  // If provided, the service will use these engines; otherwise it will create defaults
+  ragEngine?: RAGEngine;
+  sparqlEngine?: SPARQLQueryEngine;
+}
+
+export interface RAGSparqlRequest {
+  question: string;
+  maxContextDocs?: number;
+}
+
+export interface RAGSparqlAnswer {
+  question: string;
+  answer: string;
+  confidence: number;
+  contextDocs: number;
+  sparql?: {
+    query: string;
+    explanation?: string;
+  };
+  rdfSummary?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface NL2SPARQLTranslator {
+  translate(question: string): Promise<string>;
+}
+
+export class PassthroughNL2SPARQLTranslator implements NL2SPARQLTranslator {
+  // We rely on SPARQLQueryEngine's internal NL2SPARQL generation,
+  // so this translator simply returns the original question as a hint.
+  async translate(question: string): Promise<string> {
+    logger.debug('PassthroughNL2SPARQLTranslator used');
+    return question;
+  }
+}
+
+export function rowsToDocuments(resp: SPARQLQueryResponse, limit = 20): Document[] {
+  const docs: Document[] = [];
+  const rows = resp.executionResult?.data || [];
+  const max = Math.min(limit, rows.length);
+  for (let i = 0; i < max; i++) {
+    const row = rows[i];
+    const content = Object.entries(row)
+      .map(([k, v]) => `${k}: ${v.value}${v.datatype ? `^^${v.datatype}` : ''}`)
+      .join('\n');
+    docs.push(new Document({
+      pageContent: `SPARQL Row ${i + 1}:\n${content}`,
+      metadata: {
+        source: 'rdf/sparql',
+        rowIndex: i,
+        queryId: resp.metadata?.queryId,
+        intent: resp.interpretedQuery?.intent,
+      }
+    }));
+  }
+  // If no rows, still include the formatted response as a single doc for context
+  if (docs.length === 0 && resp.formattedResponse) {
+    docs.push(new Document({
+      pageContent: `SPARQL Results Summary:\n${resp.formattedResponse}`,
+      metadata: {
+        source: 'rdf/sparql-summary',
+        queryId: resp.metadata?.queryId,
+        intent: resp.interpretedQuery?.intent,
+      }
+    }));
+  }
+  return docs;
+}

--- a/src/services/layer3/types.ts
+++ b/src/services/layer3/types.ts
@@ -155,6 +155,11 @@ export interface Layer3Config {
     };
   };
 
+  // RAG+SPARQL integration toggle
+  ragSparql?: {
+    enabled: boolean;
+  };
+
   // Global settings
   global: {
     defaultProvider: 'openai' | 'anthropic' | 'local';

--- a/src/services/mcp-server/MCPServer.ts
+++ b/src/services/mcp-server/MCPServer.ts
@@ -411,6 +411,8 @@ export class MCPServer extends EventEmitter {
         return await this.handleQueryKnowledge(params.arguments);
       case 'analyze_code':
         return await this.handleAnalyzeCode(params.arguments);
+      case 'ragSparqlQuery':
+        return await this.handleRAGSparqlQuery(params.arguments);
       default:
         throw new MCPServerError('METHOD_NOT_FOUND', `Tool not found: ${params.name}`);
     }
@@ -504,6 +506,41 @@ export class MCPServer extends EventEmitter {
         content: [{
           type: 'text',
           text: `Error analyzing code: ${error instanceof Error ? error.message : String(error)}`
+        }],
+        isError: true
+      };
+    }
+  }
+
+  /**
+   * Handle RAG+SPARQL query tool call
+   */
+  private async handleRAGSparqlQuery(args: any): Promise<MCPToolResult> {
+    try {
+      if (!this.ragSparqlService) {
+        throw new Error('RAG+SPARQL integration is not enabled. Start with --enable-rag-sparql.');
+      }
+      if (!args || typeof args.question !== 'string' || !args.question.trim()) {
+        throw new Error('Invalid arguments: "question" is required');
+      }
+
+      const answer = await this.ragSparqlService.ask({
+        question: args.question,
+        maxContextDocs: args.maxContextDocs
+      });
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify(answer, null, 2)
+        }]
+      };
+    } catch (error) {
+      logger.error('RAG+SPARQL query failed', { error });
+      return {
+        content: [{
+          type: 'text',
+          text: `Error processing RAG+SPARQL query: ${error instanceof Error ? error.message : String(error)}`
         }],
         isError: true
       };

--- a/src/services/mcp-server/MCPServer.ts
+++ b/src/services/mcp-server/MCPServer.ts
@@ -17,6 +17,7 @@ import { v4 as uuidv4 } from 'uuid';
 import logger from '../../utils/logger';
 import { AIQueryRequest, AIQueryResponse } from '../layer3/index';
 import { HybridStorageManager } from '../layer2/hybrid-storage/HybridStorageManager';
+import { RAGSparqlService } from '../layer3/rag-sparql-integration';
 
 // Generic query service interface that can be either Layer3AIService or direct Neo4j service
 interface QueryService {
@@ -50,6 +51,7 @@ import {
  * MCP Server for IDE Integration
  */
 export class MCPServer extends EventEmitter {
+  private ragSparqlService?: RAGSparqlService;
   private config: MCPServerConfig;
   private server: Server;
   private wsServer: WebSocketServer;
@@ -80,6 +82,17 @@ export class MCPServer extends EventEmitter {
     // this._hybridStorage = hybridStorage;
     // Store for future use when needed
     hybridStorage;
+
+    // Initialize optional RAG+SPARQL integration
+    if (this.config.integration?.layer3Config?.ragSparql?.enabled) {
+      try {
+        this.ragSparqlService = new RAGSparqlService();
+        logger.info('RAG+SPARQL integration enabled');
+      } catch (error) {
+        logger.warn('Failed to initialize RAG+SPARQL integration', { error });
+      }
+    }
+
     this.metrics = this.initializeMetrics();
     
     // Create HTTP server with health endpoint
@@ -367,6 +380,22 @@ export class MCPServer extends EventEmitter {
         }
       }
     ];
+
+    // Conditionally expose RAG+SPARQL tool
+    if (this.ragSparqlService) {
+      tools.push({
+        name: 'ragSparqlQuery',
+        description: 'Ask a natural language question over RDF knowledge and enrich with RAG',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            question: { type: 'string', description: 'Natural language question' },
+            maxContextDocs: { type: 'number', description: 'Limit number of RDF result docs to feed into RAG' }
+          },
+          required: ['question']
+        }
+      });
+    }
 
     return { tools };
   }

--- a/src/services/mcp-server/index.ts
+++ b/src/services/mcp-server/index.ts
@@ -140,6 +140,9 @@ export function createDefaultMCPConfig(): MCPServerConfig {
             maxSize: 1000
           }
         },
+        ragSparql: {
+          enabled: false
+        },
         global: {
           defaultProvider: 'openai',
           fallbackProvider: 'openai',


### PR DESCRIPTION
…F querying system. Add new utilities and types to support service functionality. Update dependencies to include required modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds an optional SPARQL-backed RAG Q&A service that converts NL questions to SPARQL, uses RDF-derived context, and returns enriched answers (confidence, context doc count, SPARQL query/explanation).
  - Adds a ragSparqlQuery tool exposed when the integration is enabled.

- **Configuration**
  - New toggle to enable the SPARQL-backed RAG integration (default: off) and a CLI flag --enable-rag-sparql.

- **Changes**
  - Removed LLM temperature field from RAG configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->